### PR TITLE
Fix broadcom vendor driver

### DIFF
--- a/drivers/net/wireless/broadcom/bcmdhd/Makefile
+++ b/drivers/net/wireless/broadcom/bcmdhd/Makefile
@@ -26,7 +26,7 @@ DHDCFLAGS = -Wall -Wstrict-prototypes -Dlinux -DBCMDRIVER                 \
 	-DPOWERUP_MAX_RETRY=0 -DIFACE_HANG_FORCE_DEV_CLOSE -DWAIT_DEQUEUE     \
 	-DWL_EXT_IAPSTA -DWL_ESCAN -DCCODE_LIST                               \
 	-DENABLE_INSMOD_NO_FW_LOAD                                            \
-	-Idrivers/net/wireless/broadcom/bcmdhd -Idrivers/net/wireless/broadcom/bcmdhd/include
+	-I$(srctree)/drivers/net/wireless/broadcom/bcmdhd -I$(srctree)/drivers/net/wireless/broadcom/bcmdhd/include
 
 DHDOFILES = aiutils.o siutils.o sbutils.o bcmutils.o bcmwifi_channels.o   \
 	dhd_linux.o dhd_linux_platdev.o dhd_linux_sched.o dhd_pno.o           \

--- a/drivers/net/wireless/broadcom/bcmdhd/wl_cfg80211.h
+++ b/drivers/net/wireless/broadcom/bcmdhd/wl_cfg80211.h
@@ -407,7 +407,9 @@ do {									\
 /* TODO: even in upstream linux(v5.0), FT-1X-SHA384 isn't defined and supported yet.
  * need to revisit here to sync correct name later.
  */
+#ifndef WLAN_AKM_SUITE_FT_8021X_SHA384
 #define WLAN_AKM_SUITE_FT_8021X_SHA384		0x000FAC0D
+#endif
 
 #define WL_AKM_SUITE_SHA256_1X  0x000FAC05
 #define WL_AKM_SUITE_SHA256_PSK 0x000FAC06


### PR DESCRIPTION
This pull-request fixes out-of-tree compilation and silences a noisy warning in the broadcom vendor driver.