### PR TITLE
drivers/net/wireless/broadcom: fix out of tree build

### DIFF
--- a/drivers/net/wireless/broadcom/bcmdhd/Makefile
+++ b/drivers/net/wireless/broadcom/bcmdhd/Makefile
@@ -26,7 +26,7 @@ DHDCFLAGS = -Wall -Wstrict-prototypes -Dlinux -DBCMDRIVER                 \
 	-DPOWERUP_MAX_RETRY=0 -DIFACE_HANG_FORCE_DEV_CLOSE -DWAIT_DEQUEUE     \
 	-DWL_EXT_IAPSTA -DWL_ESCAN -DCCODE_LIST                               \
 	-DENABLE_INSMOD_NO_FW_LOAD                                            \
-	-Idrivers/net/wireless/broadcom/bcmdhd -Idrivers/net/wireless/broadcom/bcmdhd/include
+	-I$(srctree)/drivers/net/wireless/broadcom/bcmdhd -I$(srctree)/drivers/net/wireless/broadcom/bcmdhd/include
 
 DHDOFILES = aiutils.o siutils.o sbutils.o bcmutils.o bcmwifi_channels.o   \
 	dhd_linux.o dhd_linux_platdev.o dhd_linux_sched.o dhd_pno.o           \


### PR DESCRIPTION
Building out of tree fails due to incorrect include paths.

Fixes: 607862a03f15 ("drivers/net/wireless/broadcom: Add WiFi/BT driver BCMDHD")
Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>