### PR TITLE
drivers/video/fbdev/starfive/starfive_mipi_tx: correct va_start

### DIFF
--- a/drivers/video/fbdev/starfive/starfive_mipi_tx.c
+++ b/drivers/video/fbdev/starfive/starfive_mipi_tx.c
@@ -561,7 +561,7 @@ int dsitx_dcs_write(struct sf_fb_data *sf_dev, int n, ...)
 
     wbuf.len = 0;
     wbuf.val32 = 0;
-    va_start(ap, cmd_size);
+    va_start(ap, n);
     for (i = 0; i < cmd_size; i++) {
         wbuf.val8[wbuf.len++] = (char)va_arg(ap, int);
         if (((i + 1) & 0x3) == 0) {


### PR DESCRIPTION
The second parameter of va_start() must be the last function parameter
and not a local variable.

Fixes: 81ed1feeee13 ("drivers/video/fbdev and drivers/media/platform")
Signed-off-by: Heinrich Schuchardt <xypron.glpk@gmx.de>