### PR TITLE
Fix dts gpio reg esmil starlight

### DIFF
--- a/Documentation/devicetree/bindings/gpio/starfive,jh7100-gpio.yaml
+++ b/Documentation/devicetree/bindings/gpio/starfive,jh7100-gpio.yaml
@@ -47,19 +47,14 @@ additionalProperties: false
 
 examples:
   - |
-      soc {
-        #address-cells = <2>;
-        #size-cells = <2>;
-
-        gpio@11910000 {
-          compatible = "starfive,jh7100-gpio";
-          reg = <0x0 0x11910000 0x0 0x10000>;
-          gpio-controller;
-          #gpio-cells = <2>;
-          interrupt-controller;
-          #interrupt-cells = <2>;
-          interrupts = <32>;
-        };
+      gpio@11910000 {
+        compatible = "starfive,jh7100-gpio";
+        reg = <0x0 0x11910000 0x0 0x10000>;
+        gpio-controller;
+        #gpio-cells = <2>;
+        interrupt-controller;
+        #interrupt-cells = <2>;
+        interrupts = <32>;
       };
 
 ...

--- a/arch/riscv/boot/dts/starfive/jh7100.dtsi
+++ b/arch/riscv/boot/dts/starfive/jh7100.dtsi
@@ -260,7 +260,7 @@
 
 		gpio: gpio@11910000 {
 			compatible = "starfive,jh7100-gpio";
-			reg = <0x0 0x11910000 0x0 0x10000>;
+			reg = <0x11910000 0x10000>;
 			gpio-controller;
 			#gpio-cells = <2>;
 			interrupt-controller;


### PR DESCRIPTION
Per @geertu comments: https://github.com/starfive-tech/linux/pull/23#issuecomment-851965363
> Please make the following change to the example in the GPIO DT bindings:
> ```
> - reg = <0x0 0x11910000 0x0 0x10000>;
> + reg = <0x11910000 0x10000>;
> ```
> and drop the surrounding "soc" node and related #{address,size}-cells.
> By convention, all examples on the MMIO bus use #{address,size}-cells = <1>.

I have made those changes and the checks seem to pass ok:
```
pdp7@x1:~/dev/starfive/linux$ make -j8 ARCH=riscv CROSS_COMPILE=riscv64-linux-gnu- dt_binding_check DT_SCHEMA_FILES=Documentation/devicetree/bindings/gpio/starfive,jh7100-gpio.yaml
  CHKDT   Documentation/devicetree/bindings/processed-schema-examples.json
  DTEX    Documentation/devicetree/bindings/gpio/starfive,jh7100-gpio.example.dts
/home/pdp7/dev/starfive/linux/Documentation/devicetree/bindings/media/renesas,drif.yaml: properties:clock-names:maxItems: False schema does not allow 1
	hint: "minItems/maxItems" equal to the "items" list length are not necessary
	from schema $id: http://devicetree.org/meta-schemas/items.yaml#
  SCHEMA  Documentation/devicetree/bindings/processed-schema-examples.json
/home/pdp7/dev/starfive/linux/Documentation/devicetree/bindings/media/renesas,drif.yaml: ignoring, error in schema: properties: clock-names: maxItems
warning: no schema found in file: ./Documentation/devicetree/bindings/media/renesas,drif.yaml
  DTC     Documentation/devicetree/bindings/gpio/starfive,jh7100-gpio.example.dt.yaml
  CHECK   Documentation/devicetree/bindings/gpio/starfive,jh7100-gpio.example.dt.yaml
/home/pdp7/dev/starfive/linux/Documentation/devicetree/bindings/gpio/starfive,jh7100-gpio.example.dt.yaml: example-0: gpio@11910000:reg:0: [0, 294715392, 0, 65536] is too long
	From schema: /home/pdp7/.local/lib/python3.8/site-packages/dtschema/schemas/reg.yaml

pdp7@x1:~/dev/starfive/linux$ make -j8 ARCH=riscv CROSS_COMPILE=riscv64-linux-gnu- dtbs_check DT_SCHEMA_FILES=Documentation/devicetree/bindings/gpio/starfive,jh7100-gpio.yaml 
```
