### PR TITLE
riscv: dts: add PWM pinctrl config of the StarFive Starlight board

### DIFF
--- a/arch/riscv/boot/dts/starfive/jh7100-beaglev-starlight.dts
+++ b/arch/riscv/boot/dts/starfive/jh7100-beaglev-starlight.dts
@@ -355,6 +355,32 @@
 			slew-rate = <0>;
 		};
 	};
+	pwm_pins: pwm_pins-0 {
+		ptc-pins {
+			pinmux = <GPIOMUX(7,
+				  GPO_PWM_PAD_OUT_BIT0,
+				  GPO_PWM_PAD_OE_N_BIT0,
+				  GPI_NONE)>,
+				 <GPIOMUX(5,
+				  GPO_PWM_PAD_OUT_BIT1,
+				  GPO_PWM_PAD_OE_N_BIT1,
+				  GPI_NONE)>,
+				 <GPIOMUX(45,
+				  GPO_PWM_PAD_OUT_BIT2,
+				  GPO_PWM_PAD_OE_N_BIT2, GPI_NONE)>;
+			bias-disable;
+			drive-strength = <35>;
+			input-disable;
+			input-schmitt-disable;
+			slew-rate = <0>;
+		};
+	};
+};
+
+&ptc {
+	pinctrl-names = "default";
+	pinctrl-0 = <&pwm_pins>;
+	status = "okay";
 };
 
 &i2c0 {


### PR DESCRIPTION
Signed-off-by: Jianlong Huang <jianlong.huang@starfivetech.com>