### PR TITLE
riscv: dts: starfive: Modify devicee tree for VisionFive to support W…

### DIFF
--- a/arch/riscv/boot/dts/starfive/jh7100-visionfive.dts
+++ b/arch/riscv/boot/dts/starfive/jh7100-visionfive.dts
@@ -20,7 +20,7 @@
 
 &gpio {
 	/* don't reset gpio mux for serial console and reset gpio */
-	starfive,keep-gpiomux = <13 14 63>;
+	starfive,keep-gpiomux = <13 14 63 0 2 3 45>;
 };
 
 &i2c0 {


### PR DESCRIPTION
…M8960 daughter board

Modify the gpio node to keep i2s pins state.
Based on the device tree in https://github.com/starfive-tech/u-boot/

Signed-off-by: Som Qin <som.qin@starfivetech.com>