### PR TITLE
dts: starfive: Amend Venc module's nodes in device tree

### DIFF
--- a/arch/riscv/boot/dts/starfive/jh7100.dtsi
+++ b/arch/riscv/boot/dts/starfive/jh7100.dtsi
@@ -634,8 +634,18 @@
 			compatible = "cm,cm521-vpu";
 			reg = <0x0 0x118e0000 0x0 0x4000>;
 			reg-names = "control";
-			clocks = <&clkgen JH7100_CLK_VP6_CORE>;
-			clock-names = "vcodec";
+			clocks =<&clkgen JH7100_CLK_VENC_AXI>,
+					<&clkgen JH7100_CLK_VENCBRG_MAIN>,
+					<&clkgen JH7100_CLK_VENC_BCLK>,
+					<&clkgen JH7100_CLK_VENC_CCLK>,
+					<&clkgen JH7100_CLK_VENC_APB>;
+			clock-names = "venc_axi", "vencbrg_main", "venc_bclk", "venc_cclk", "venc_apb";
+			resets = <&rstgen JH7100_RSTN_VENC_AXI>,
+					<&rstgen JH7100_RSTN_VENCBRG_MAIN>,
+					<&rstgen JH7100_RSTN_VENC_BCLK>,
+					<&rstgen JH7100_RSTN_VENC_CCLK>,
+					<&rstgen JH7100_RSTN_VENC_APB>;
+			reset-names = "venc_axi", "vencbrg_main", "venc_bclk", "venc_cclk", "venc_apb";
 			interrupts = <26>;
 		};
 


### PR DESCRIPTION
Add properties of clock and reset in Venc module device tree.

Signed-off-by: Xingyu Wu <xingyu.wu@starfivetech.com>