### PR TITLE
Drop default initrd addresses from jh7110 dts

### DIFF
--- a/arch/riscv/boot/dts/starfive/jh7110-common.dtsi
+++ b/arch/riscv/boot/dts/starfive/jh7110-common.dtsi
@@ -29,8 +29,6 @@
 	};
 
 	chosen {
-		linux,initrd-start = <0x0 0x46100000>;
-		linux,initrd-end = <0x0 0x4c000000>;
 		stdout-path = "serial0:115200";
 		#bootargs = "debug console=ttyS0 rootwait";
 	};

--- a/arch/riscv/boot/dts/starfive/jh7110-visionfive-v2.dtsi
+++ b/arch/riscv/boot/dts/starfive/jh7110-visionfive-v2.dtsi
@@ -34,8 +34,6 @@
 	};
 
 	chosen {
-		linux,initrd-start = <0x0 0x46100000>;
-		linux,initrd-end = <0x0 0x4c000000>;
 		stdout-path = "serial0:115200";
 		#bootargs = "debug console=ttyS0 rootwait";
 	};


### PR DESCRIPTION
Fixes crash on boot without an initrd. u-boot will readd them if booting with an initrd.