### PR TITLE
[Bugfix] crypto: dh - constify struct dh's pointer members

### DIFF
--- a/security/keys/dh.c
+++ b/security/keys/dh.c
@@ -14,7 +14,7 @@
 #include <keys/user-type.h>
 #include "internal.h"
 
-static ssize_t dh_data_from_key(key_serial_t keyid, void **data)
+static ssize_t dh_data_from_key(key_serial_t keyid, const void **data)
 {
 	struct key *key;
 	key_ref_t key_ref;


### PR DESCRIPTION
Const defined in `dh.h` but non-const in `dh.c`.