### PR TITLE
spi-cadence-quadspi: remove unused variable

### DIFF
--- a/drivers/spi/spi-cadence-quadspi.c
+++ b/drivers/spi/spi-cadence-quadspi.c
@@ -1251,7 +1251,6 @@ static int cqspi_mem_process(struct spi_mem *mem, const struct spi_mem_op *op)
 static int cqspi_exec_mem_op(struct spi_mem *mem, const struct spi_mem_op *op)
 {
 	int ret;
-	struct cqspi_st *cqspi = spi_master_get_devdata(mem->spi->master);
 
 	if (op->cmd.opcode == SPINOR_OP_RDCR) {
 		reset_control_assert(cqspi->qspi_rst);


### PR DESCRIPTION
Introduced with the last commit https://github.com/starfive-tech/linux/commit/16d2a17eb3, the kernel build now seems to correctly indicate that `*cqspi` is unused and hence the declaration should be removed from this function:
```
  CC      drivers/spi/spi-cadence-quadspi.o
drivers/spi/spi-cadence-quadspi.c: In function ‘cqspi_exec_mem_op’:
drivers/spi/spi-cadence-quadspi.c:1233:26: warning: unused variable ‘cqspi’ [-Wunused-variable]
 1233 |         struct cqspi_st *cqspi = spi_master_get_devdata(mem->spi->master);
      | 
```