### PR TITLE
ASoC: wm8960: restore missing MODULE_LICENSE

### DIFF
--- a/sound/soc/codecs/wm8960.c
+++ b/sound/soc/codecs/wm8960.c
@@ -1722,4 +1722,4 @@ module_i2c_driver(wm8960_i2c_driver);
 
 MODULE_DESCRIPTION("ASoC WM8960 driver");
 MODULE_AUTHOR("Liam Girdwood");
-
+MODULE_LICENSE("GPL v2");


### PR DESCRIPTION
Accidentally removed in edd12a5579cb4f1a7a7ae5ceb50997df81c411b5