### PR TITLE
Input: joystick - fix Kconfig warning for JOYSTICK_ADC

### DIFF
--- a/drivers/input/joystick/Kconfig
+++ b/drivers/input/joystick/Kconfig
@@ -46,6 +46,7 @@ config JOYSTICK_A3D
 config JOYSTICK_ADC
 	tristate "Simple joystick connected over ADC"
 	depends on IIO
+	select IIO_BUFFER
 	select IIO_BUFFER_CB
 	help
 	  Say Y here if you have a simple joystick connected over ADC.


### PR DESCRIPTION
Fix: https://github.com/deepin-community/deepin-riscv-kernel/actions/runs/6320541745/job/17163185895
Fix: https://github.com/deepin-community/deepin-riscv-kernel/actions/runs/6333699747/job/17202178605

unmet direct dependencies detected for IIO_BUFFER_CB
Depends on [n]: IIO [=y] && IIO_BUFFER [=n]
Selected by [m]:
JOYSTICK_ADC [=m] && INPUT [=y] && INPUT_JOYSTICK [=y] && IIO [=y]

[ Upstream commit 6100a19c4fcfe154dd32f8a8ef4e8c0b1f607c75 ]
