### PR TITLE
Apply workaround to allow for bridging between the two ethrnet ports on VF2

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
+++ b/drivers/net/ethernet/stmicro/stmmac/dwmac4_core.c
@@ -450,12 +450,6 @@ static int dwmac4_add_hw_vlan_rx_fltr(struct net_device *dev,
 	if (vid > 4095)
 		return -EINVAL;
 
-	if (hw->promisc) {
-		netdev_err(dev,
-			   "Adding VLAN in promisc mode not supported\n");
-		return -EPERM;
-	}
-
 	/* Single Rx VLAN Filter */
 	if (hw->num_vlan == 1) {
 		/* For single VLAN filter, VID 0 means VLAN promiscuous */
@@ -504,12 +498,6 @@ static int dwmac4_del_hw_vlan_rx_fltr(struct net_device *dev,
 				      __be16 proto, u16 vid)
 {
 	int i, ret = 0;
-
-	if (hw->promisc) {
-		netdev_err(dev,
-			   "Deleting VLAN in promisc mode not supported\n");
-		return -EPERM;
-	}
 
 	/* Single Rx VLAN Filter */
 	if (hw->num_vlan == 1) {


### PR DESCRIPTION
When trying to use NetworkManager to bridge the two ethernet ports on VF2 on current kernel, there is an error `Adding VLAN in promisc mode not supported` message in the journal. So I applied [this workaround](https://community.nxp.com/t5/i-MX-Processors-Knowledge-Base/Workaround-for-issue-Bridge-mode-on-EQoS-module-will-not-work/ta-p/1559302) from [armbian](https://forum.armbian.com/topic/26518-network-bridge-fails-to-initialize-vlan-in-promisc-mode-not-supported/), which successfully allowed me to bridge the two ethernet ports as shown here. 

![image](https://github.com/starfive-tech/linux/assets/30728609/2c0ee15e-a911-4709-a83d-4b6c8757873c)

I submitted a [PR](https://github.com/cwt-vf2/linux-cwt-starfive-vf2/pull/6) to add it to the archlinux image kernel, but adding this to this upstream kernel would be helpful, so that newer versions of the build will continue to work, until the upstream process is complete and later versions of the kernel can be used. 