### PR TITLE
drm/starfive: set FOP_UNSIGNED_OFFSET in starfive_drm_driver_fops

### DIFF
--- a/drivers/gpu/drm/starfive/starfive_drm_drv.c
+++ b/drivers/gpu/drm/starfive/starfive_drm_drv.c
@@ -56,6 +56,7 @@ static const struct file_operations starfive_drm_driver_fops = {
 	.unlocked_ioctl = drm_ioctl,
 	.compat_ioctl = drm_compat_ioctl,
 	.release = drm_release,
+	.fop_flags = FOP_UNSIGNED_OFFSET,
 };
 
 static struct drm_driver starfive_drm_driver = {


### PR DESCRIPTION
This fixes the error from drm_open:

[  +0.000020] [      C1] WARNING: CPU: 1 PID: 1110 at drivers/gpu/drm/drm_file.c

Signed-off-by: Andreas Schwab <schwab@suse.de>
