### PR TITLE
phy: m31: correct printf code in sys_m31_dphy_tx_configure()

### DIFF
--- a/drivers/phy/m31/phy-m31-dphy-tx0.c
+++ b/drivers/phy/m31/phy-m31-dphy-tx0.c
@@ -226,7 +226,7 @@ static int sys_m31_dphy_tx_configure(struct phy *phy, union phy_configure_opts *
 	dphy = phy_get_drvdata(phy);	
 
 	bitrate = opts->mipi_dphy.hs_clk_rate;//1188M 60fps
-	dev_info(dphy->dev, "%s bitrate = %ld\n", __func__, bitrate);
+	dev_info(dphy->dev, "%s bitrate = %d\n", __func__, bitrate);
 
 	sf_dphy_set_reg(dphy->topsys + 0x8, 0x10, 
 					RG_CDTX_L0N_HSTX_RES_SHIFT, RG_CDTX_L0N_HSTX_RES_MASK);


### PR DESCRIPTION
Building results in a warning

    drivers/phy/m31/phy-m31-dphy-tx0.c:229:29: warning: format ‘%ld’
    expects argument of type ‘long int’, but argument 4 has type
    ‘uint32_t’ {aka ‘unsigned int’} [-Wformat=]

    drivers/phy/m31/phy-m31-dphy-tx0.c:229:45: note: format string is defined here
      229 | dev_info(dphy->dev, "%s bitrate = %ld\n", __func__, bitrate);
          |                                   ~~^
          |                                     |
          |                                     long int

Change to printf code to %d.