### PR TITLE
Jh7110 vision five2 6.12.y devel

### DIFF
--- a/drivers/gpu/drm/img/img-rogue/services/server/common/mmu_common.c
+++ b/drivers/gpu/drm/img/img-rogue/services/server/common/mmu_common.c
@@ -3035,7 +3035,9 @@ MMU_MapPages(MMU_CONTEXT *psMMUContext,
 	IMG_UINT32 uiPTEIndex = 0;
 	IMG_UINT32 uiPageSize = (1 << uiLog2HeapPageSize);
 	IMG_UINT32 uiLoop = 0;
+#if defined(PDUMP)
 	IMG_UINT32 ui32MappedCount = 0;
+#endif /*PDUMP*/
 	IMG_DEVMEM_OFFSET_T uiPgOffset = 0;
 	IMG_UINT32 uiFlushEnd = 0, uiFlushStart = 0;
 
@@ -3333,7 +3335,9 @@ MMU_MapPages(MMU_CONTEXT *psMMUContext,
 						sDevVAddr.uiAddr,
 						uiPgOffset * uiPageSize));
 
+#if defined(PDUMP)
 				ui32MappedCount++;
+#endif /*PDUMP*/
 			}
 		}
 

--- a/drivers/gpu/drm/img/img-rogue/services/server/common/sync_checkpoint.c
+++ b/drivers/gpu/drm/img/img-rogue/services/server/common/sync_checkpoint.c
@@ -3091,7 +3091,10 @@ static IMG_UINT32 _CleanCheckpointPool(_SYNC_CHECKPOINT_CONTEXT *psContext)
 	DECLARE_DLLIST(sCleanupList);
 	DLLIST_NODE *psThis, *psNext;
 	OS_SPINLOCK_FLAGS uiFlags;
-	IMG_UINT32 ui32ItemsFreed = 0, ui32NullScpCount = 0, __maybe_unused ui32PoolCount;
+	IMG_UINT32 ui32ItemsFreed = 0, __maybe_unused ui32PoolCount;
+#if (ENABLE_SYNC_CHECKPOINT_POOL_DEBUG == 1)
+	IMG_UINT32 ui32NullScpCount = 0;
+#endif
 
 	/* Acquire sync checkpoint pool lock */
 	OSSpinLockAcquire(psCtxCtl->hSyncCheckpointPoolLock, uiFlags);
@@ -3116,10 +3119,12 @@ static IMG_UINT32 _CleanCheckpointPool(_SYNC_CHECKPOINT_CONTEXT *psContext)
 			 * from the list so it's safe to use sListNode here */
 			dllist_add_to_head(&sCleanupList, &psCheckpoint->sListNode);
 		}
+#if (ENABLE_SYNC_CHECKPOINT_POOL_DEBUG == 1)
 		else
 		{
 			ui32NullScpCount++;
 		}
+#endif
 	}
 
 	/* Release sync checkpoint pool lock */

--- a/drivers/gpu/drm/img/img-rogue/services/server/devices/rgxhwperf_common.c
+++ b/drivers/gpu/drm/img/img-rogue/services/server/devices/rgxhwperf_common.c
@@ -3500,7 +3500,9 @@ PVRSRV_ERROR RGXHWPerfAcquireEvents(
 	PVRSRV_ERROR			eError;
 	RGX_KM_HWPERF_DEVDATA*	psDevData = (RGX_KM_HWPERF_DEVDATA*)hDevData;
 	IMG_PBYTE				pDataDest;
+#if defined(DEBUG) || defined(DOXYGEN)
 	IMG_UINT32			ui32TlPackets = 0;
+#endif
 	IMG_PBYTE			pBufferEnd;
 	PVRSRVTL_PPACKETHDR psHDRptr;
 	PVRSRVTL_PACKETTYPE ui16TlType;
@@ -3578,10 +3580,14 @@ PVRSRV_ERROR RGXHWPerfAcquireEvents(
 		psHDRptr = GET_NEXT_PACKET_ADDR(psHDRptr);
 		/* Updated to keep track of the next packet to be read. */
 		psDevData->pTlBufRead[eStreamId] = (IMG_PBYTE) ((void *)psHDRptr);
+#if defined(DEBUG) || defined(DOXYGEN)
 		ui32TlPackets++;
+#endif
 	}
 
+#if defined(DEBUG) || defined(DOXYGEN)
 	PVR_DPF((PVR_DBG_VERBOSE, "RGXHWPerfAcquireEvents: TL Packets processed %03d", ui32TlPackets));
+#endif
 
 	psDevData->bRelease[eStreamId] = IMG_FALSE;
 	if (psHDRptr >= (PVRSRVTL_PPACKETHDR)((void *)pBufferEnd))

--- a/scripts/gcc-plugins/gcc-common.h
+++ b/scripts/gcc-plugins/gcc-common.h
@@ -299,7 +299,9 @@ typedef const gimple *const_gimple_ptr;
 #define gimple gimple_ptr
 #define const_gimple const_gimple_ptr
 #undef CONST_CAST_GIMPLE
-#define CONST_CAST_GIMPLE(X) CONST_CAST(gimple, (X))
+#define CONST_CAST_GIMPLE(X) const_cast<gimple>((X))
+#undef CONST_CAST_TREE
+#define CONST_CAST_TREE(X) const_cast<tree>((X))
 #endif
 
 /* gimple related */


### PR DESCRIPTION
The branch no longer compiles if using GCC 16.

Backport a fix from Linux mainline and fix the vendor GPU driver to make the kernel compile also with GCC 16.